### PR TITLE
Possibility to ignore EAR validation

### DIFF
--- a/bw-maven-plugin/src/main/java/fr/fastconnect/factory/tibco/bw/maven/compile/CompileEARMojo.java
+++ b/bw-maven-plugin/src/main/java/fr/fastconnect/factory/tibco/bw/maven/compile/CompileEARMojo.java
@@ -77,6 +77,15 @@ public class CompileEARMojo extends AbstractBWArtifactMojo {
     protected File tibcoBuildEARPath;
 
     /**
+     * <p>
+     * Whether to validate or not the EAR before building
+     * (-v switch of <i>buildear</i>).
+     * </p>
+     */
+    @Parameter(property = "buildear.validate", defaultValue = "true")
+    protected Boolean tibcoBuildEARValidation;
+
+    /**
      * Allow to delete override variables from projlib
      */
     @Parameter(property = "bw.clean.projlib.defaultVars")
@@ -122,7 +131,9 @@ public class CompileEARMojo extends AbstractBWArtifactMojo {
         arguments.add("-o"); // output file
         arguments.add(outputFile.getAbsolutePath());
         arguments.add("-x"); // overwrite the output
-        arguments.add("-v"); // validate the project
+        if (tibcoBuildEARValidation) {
+            arguments.add("-v"); // validate the project
+        }
         File aliasesFile = new File(directory, ALIASES_FILE);
         if (aliasesFile.exists()) {
             arguments.add("-a");


### PR DESCRIPTION
Added the possibility to ignore EAR validation by removing the '-v' switch of buildear parameters.

Usage in POM:

``` xml
<properties>
  <buildear.validate>false</buildear.validate>
</properties>
```

_or_

``` xml
...
<plugin>
  <groupId>fr.fastconnect.factory.tibco.bw.maven</groupId>
  <artifactId>bw-maven-plugin</artifactId>
  <version>${bw.maven.plugin.version}</version>
  <extensions>true</extensions>
  <configuration>
    <tibcoBuildEARValidation>false</tibcoBuildEARValidation>
  </configuration>
<plugin>
...
```
