### PR TITLE
Forward properties

### DIFF
--- a/bw-maven-plugin/src/main/java/fr/fastconnect/factory/tibco/bw/maven/packaging/pom/AbstractPOMGenerator.java
+++ b/bw-maven-plugin/src/main/java/fr/fastconnect/factory/tibco/bw/maven/packaging/pom/AbstractPOMGenerator.java
@@ -20,6 +20,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
@@ -62,11 +64,27 @@ public abstract class AbstractPOMGenerator extends AbstractPackagingMojo {
 	protected PluginDescriptor pluginDescriptor;
 
 	/**
+	 * <p>
 	 * All properties in original model with this prefix will be
 	 * copied to the deployment POM.
+	 * </p>
 	 */
 	@Parameter (property="deploy.pom.forwardPropertyPrefix", defaultValue="deploymentProperty_")
 	protected String deploymentPropertyPrefix;
+
+	/**
+	 * <p>
+	 * All properties listed in the plugin configuration will be copied to
+	 * the deployment POM.
+	 * </p>
+	 * <p>For instance:<br /><pre>
+	 *   &lt;deploymentProperties>
+	 *     &lt;deploymentProperty>someProperty&lt;/deploymentProperty>
+	 *   &lt;/deploymentProperties></pre>
+	 * </p>
+	 */
+	@Parameter
+	protected List<String> deploymentProperties; 
 
 	protected abstract File getOutputFile();
 	protected abstract File getTemplateFile();
@@ -144,6 +162,9 @@ public abstract class AbstractPOMGenerator extends AbstractPackagingMojo {
 				if (property != null && property.startsWith(deploymentPropertyPrefix)) {
 					model.getProperties().put(property.substring(deploymentPropertyPrefix.length()), originalProperties.getProperty(property));
 				}
+				if (property != null && deploymentProperties.contains(property)) {
+					model.getProperties().put(property, originalProperties.getProperty(property));
+				}
 			}
 
 			model = updateModel(model, project); 
@@ -164,6 +185,10 @@ public abstract class AbstractPOMGenerator extends AbstractPackagingMojo {
 	}
 
 	public void execute() throws MojoExecutionException {
+		if (deploymentProperties == null) {
+			deploymentProperties = new ArrayList<String>();
+		}
+
 		Boolean skipParent = super.skip();
 		if (skipParent || getSkipGeneratePOM()) {
 			if (!skipParent) {


### PR DESCRIPTION
Ability to include in deployment POMs some properties of the project's Maven model
Two kinds of properties are forwarded:
- the ones starting with **"deploymentProperty_"** constant string (configurable with _deploy.pom.forwardPropertyPrefix_ parameter). Only the string after the constant will be the key in the deployment POM. For instance:<pre> &lt;deploymentProperty_somePropertyToForward>someValue&lt;/deploymentProperty_somePropertyToForward></pre> in POM will become in deployment POM:<pre>&lt;somePropertyToForward>someValue&lt;/somePropertyToForward></pre>
- the ones listed in the plugin configuration like this:<pre>
  &lt;deploymentProperties>
  &nbsp;&nbsp;&lt;deploymentProperty>someProperty&lt;/deploymentProperty>
  &lt;/deploymentProperties></pre>
