### PR TITLE
Load alias file while compiling .projlib

### DIFF
--- a/bw-maven-plugin/src/main/java/fr/fastconnect/factory/tibco/bw/maven/compile/CompileProjlibMojo.java
+++ b/bw-maven-plugin/src/main/java/fr/fastconnect/factory/tibco/bw/maven/compile/CompileProjlibMojo.java
@@ -112,6 +112,11 @@ public class CompileProjlibMojo extends AbstractBWArtifactMojo {
 		if (!hideLibraryResources) {
 			arguments.add("-v"); // validate the project
 		}
+		File aliasesFile = new File(directory, ALIASES_FILE);
+		if (aliasesFile.exists()) {
+			arguments.add("-a");
+			arguments.add(aliasesFile.getAbsolutePath());
+		}
 
 		getLog().info(BUILDING_PROJLIB);
 


### PR DESCRIPTION
Included '-a' parameter to load alias file while compiling .projlib